### PR TITLE
Lint long lines

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@
 
 It's a `flake8`_ plugin!
 It lints for style problems!
-All you have to do to activate it is::
+All one has to do to activate it is::
 
   $ pip install ebb-lint
 
@@ -176,8 +176,8 @@ L207
 
 L208
   `Pokémon exception handling <http://c2.com/cgi/wiki?PokemonExceptionHandling>`_ is always a mistake.
-  If you really intend to catch and ignore exceptions,
-  explicitly name *which* exception types you wish to silence.
+  If one really intends to catch and ignore exceptions,
+  explicitly name *which* exception types one wishes to silence.
 
 L209
   ``return``,
@@ -228,9 +228,9 @@ L212
   Using ``@staticmethod`` is always wrong.
   The two most common situations are:
 
-  - You want to do something with the class but without an instance,
+  - One wants to do something with the class but without an instance,
     in which case ``@classmethod`` is the correct solution.
-  - You want to 'namespace' a function on a class,
+  - One wants to 'namespace' a function on a class,
     but this isn't Java,
     so make it a module-scoped function instead.
 

--- a/README.rst
+++ b/README.rst
@@ -26,13 +26,28 @@ Configuration
 =============
 
 Configuration does nothing but cause bugs or laxness,
-so ``ebb-lint`` has none.
+so ``ebb-lint`` recommends keeping the defaults as-is.
+However,
+there are two configuration options provided for dealing with `long lines`_.
+Both can be specified either
+on the command line by passing flags to ``flake8``,
+or with `the typical configuration methods <https://flake8.readthedocs.org/en/stable/config.html>`_.
+
+``hard-max-line-length``
+  Lines must never be longer than this value.
+  The default is 119 columns.
+
+``permissive-bulkiness-percentage``
+  Lines can exceed ``max-line-length``
+  (which is considered the "soft limit")
+  if and only if the line contains greater than or equal to this percentage of string literals *or* comments,
+  but the percentages of each are not combined.
+  The default is 67%.
+  For more detail, see the section about `long lines`_.
 
 .. _one-off scripts:
 
-If,
-however,
-one is writing a one-off script and wishes to use ``print`` against ``ebb-lint``\ 's wishes,
+If one is writing a one-off script and wishes to use ``print`` against ``ebb-lint``\ 's wishes,
 a comment can be added to the top of the file to disable that warning::
 
   # I sincerely swear that this is one-off code.
@@ -235,11 +250,61 @@ L212
 
 
 
-L3: Whitespace
+L3: Formatting
 --------------
 
 L301
   Files must end with a trailing newline.
+
+.. _long lines:
+
+L302
+  The line was too long.
+
+  Lines greater than ``hard-max-line-length``
+  (which is considered the "hard limit",
+  and by default is 119 columns)
+  are never allowed.
+  Lines greater than ``max-line-length``
+  (which is considered the "soft limit",
+  and by default is 79 columns)
+  are allowed if and only if the line contains above a certain percentage of string literals *or* comments.
+  The percentages of both are not combined.
+  The "certain percentage" allowed is ``permissive-bulkiness-percentage``,
+  which by default is 67%.
+
+  For all of the following examples,
+  the soft limit is 15 columns,
+  and the hard limit is 25 columns.
+
+  Disallowed because,
+  at 20 characters,
+  the line exceeds the soft limit,
+  and the whole line is only 15% string literals by character count::
+
+    ultradignified = 'y'
+
+  Allowed because the whole line is 80% string literals by character count::
+
+    t = 'electroplating'
+
+  Allowed because the whole line is 75% comments by character count::
+
+    f()  # accreditation
+
+  Disallowed because the whole line is 20% comments and 50% string literals by character count,
+  and neither of those is at or above 67%::
+
+    d = 'smallpox'  # ok
+
+  Disallowed because the whole line is 26 characters long,
+  which exceeds the hard limit::
+
+    thyroparathyroidectomize()
+
+
+  The ``hard-max-line-length`` and ``permissive-bulkiness-percentage`` can be configured;
+  see the section Configuration_.
 
 
 .. _flake8: https://flake8.readthedocs.org/en/stable/

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@
 
 It's a `flake8`_ plugin!
 It lints for style problems!
-All one has to do to activate it is::
+To activate it::
 
   $ pip install ebb-lint
 
@@ -40,15 +40,16 @@ or with `the typical configuration methods <https://flake8.readthedocs.org/en/st
 ``permissive-bulkiness-percentage``
   Lines can exceed ``max-line-length``
   (which is considered the "soft limit")
-  if and only if the line contains greater than or equal to this percentage of string literals *or* comments,
+  only if the line contains greater than or equal to this percentage of string literals *or* comments,
   but the percentages of each are not combined.
   The default is 67%.
   For more detail, see the section about `long lines`_.
 
 .. _one-off scripts:
 
-If one is writing a one-off script and wishes to use ``print`` against ``ebb-lint``\ 's wishes,
-a comment can be added to the top of the file to disable that warning::
+When writing a one-off script,
+to use ``print`` against ``ebb-lint``\ 's wishes,
+add a comment to the top of the file to disable that warning::
 
   # I sincerely swear that this is one-off code.
 
@@ -176,8 +177,8 @@ L207
 
 L208
   `Pokémon exception handling <http://c2.com/cgi/wiki?PokemonExceptionHandling>`_ is always a mistake.
-  If one really intends to catch and ignore exceptions,
-  explicitly name *which* exception types one wishes to silence.
+  If the intent is *really* to catch and ignore exceptions,
+  explicitly name *which* exception types to silence.
 
 L209
   ``return``,
@@ -228,9 +229,9 @@ L212
   Using ``@staticmethod`` is always wrong.
   The two most common situations are:
 
-  - One wants to do something with the class but without an instance,
+  - Wanting to do something with the class but without an instance,
     in which case ``@classmethod`` is the correct solution.
-  - One wants to 'namespace' a function on a class,
+  - Wanting to 'namespace' a function on a class,
     but this isn't Java,
     so make it a module-scoped function instead.
 

--- a/TODO.org
+++ b/TODO.org
@@ -1,4 +1,4 @@
-*** TODO [9/14]
+*** TODO [10/16]
  - [X] check for excess stuff in __init__.py
    - [X] no functions
    - [X] no classes
@@ -18,3 +18,5 @@
  - [X] no list comps for side effects
  - [X] del/return are not functions
  - [ ] catch misuse of super
+ - [X] see if 'line too long' errors can be smarter
+ - [ ] catch docstrings as comments?

--- a/ebb_lint/errors.py
+++ b/ebb_lint/errors.py
@@ -69,8 +69,12 @@ class Errors(enum.Enum):
         212,
         '@staticmethod is always wrong; you probably want @classmethod')
 
-    whitespace_category = Error(
-        300, 'errors related to whitespace')
+    formatting_category = Error(
+        300, 'errors related to formatting')
     no_trailing_newline = Error(
         301,
         'files must end with a trailing newline')
+    line_too_long = Error(
+        302,
+        ('line too long ({length} > {which_limit} limit of {limit} '
+         'characters{extra})'))

--- a/ebb_lint/flake8.py
+++ b/ebb_lint/flake8.py
@@ -131,8 +131,8 @@ class Lines(object):
 
     def byte_of_pos(self, lineno, column):
         # This requires a bit of explanation. The source passed to lib2to3's
-        # parser has an extra newline addedin some cases, to deal with a bug in
-        # lib2to3 where it crashes hard if files don't end with a trailing
+        # parser has an extra newline added in some cases, to deal with a bug
+        # in lib2to3 where it crashes hard if files don't end with a trailing
         # newline. When that extra line is added, the final DEDENT token in the
         # file will have a lineno equal to the lines in the file plus one,
         # becase it's "at" a location that doesn't exist in the real file. If

--- a/ebb_lint/flake8.py
+++ b/ebb_lint/flake8.py
@@ -8,6 +8,7 @@ from lib2to3 import patcomp, pygram, pytree
 
 import six
 import venusian
+from intervaltree import Interval, IntervalTree
 
 from ebb_lint._version import __version__
 from ebb_lint.errors import Errors
@@ -78,18 +79,25 @@ else:  # pragma: nocover
             return pygram.python_grammar
 
 
-def find_comments(s):
+def find_comments(s, base_byte=0):
     fobj = io.StringIO(six.text_type(s))
-    for typ, tok, _, _, _ in tokenize.generate_tokens(fobj.readline):
+    lines = Lines(fobj)
+    fobj.seek(0)
+    for typ, tok, spos, epos, _ in tokenize.generate_tokens(fobj.readline):
         if typ == tokenize.COMMENT:
-            yield tok
+            yield tok, Interval(
+                lines.byte_of_pos(*spos) + base_byte,
+                lines.byte_of_pos(*epos) + base_byte)
 
 
-def parse_file(driver, filename):
+def read_file_using_source_encoding(filename):
     with open(filename, 'rb') as infile:
         encoding = tokenize.detect_encoding(infile.readline)[0]
     with io.open(filename, 'r', encoding=encoding) as infile:
-        source = infile.read()
+        return infile.read()
+
+
+def parse_source(driver, source):
     trailing_newline = not source or source.endswith('\n')
     # Thanks for this, lib2to3.
     if not trailing_newline:
@@ -105,32 +113,90 @@ class Lines(object):
             self.lines.append((count, line))
             count += len(line)
         self.last_pos = len(self.lines) - 1, len(self.lines[-1][1])
+        self.last_byte = count
 
     def __getitem__(self, idx):
         return self.lines[idx]
+
+    def __iter__(self):
+        for e, (count, line) in enumerate(self.lines):
+            if e == 0:
+                continue
+            yield e, count, line
 
     def position_of_byte(self, byte):
         lineno = bisect.bisect_left(self.lines, (byte + 1,)) - 1
         column = byte - self.lines[lineno][0]
         return lineno, column
 
+    def byte_of_pos(self, lineno, column):
+        # This requires a bit of explanation. The source passed to lib2to3's
+        # parser has an extra newline addedin some cases, to deal with a bug in
+        # lib2to3 where it crashes hard if files don't end with a trailing
+        # newline. When that extra line is added, the final DEDENT token in the
+        # file will have a lineno equal to the lines in the file plus one,
+        # becase it's "at" a location that doesn't exist in the real file. If
+        # this case wasn't specifically caught, the self[lineno] would raise an
+        # exception because lineno is beyond the last index in self.lines. So,
+        # when that case is detected, return the final byte position.
+        if lineno == len(self.lines) and column == 0:
+            return self.last_byte
+        byte, _ = self[lineno]
+        byte += column
+        return byte
+
+    def byte_of_node(self, node):
+        return self.byte_of_pos(node.lineno, node.column)
+
+
+def byte_cardinality(tree):
+    ret = 0
+    for i in tree:
+        ret += i.end - i.begin
+    return ret
+
 
 class EbbLint(object):
     name = 'ebb_lint'
     version = __version__
 
+    collected_checkers = None
+    _source = None
     _lines = None
 
     def __init__(self, tree, filename):
         self.tree = tree
         self.filename = filename
+        self._intervals = {
+            'comments': IntervalTree(),
+            'string literals': IntervalTree(),
+        }
 
     @classmethod
     def add_options(cls, parser):
-        pass
+        parser.add_option('--hard-max-line-length', default=119, type=int,
+                          metavar='n',
+                          help='absolute maximum line length allowed')
+        parser.config_options.append('hard-max-line-length')
+        parser.add_option('--permissive-bulkiness-percentage', default=67,
+                          type=int, metavar='p', help=(
+                              'integer percentage of a line which must be '
+                              'string literals or comments to be allowed to '
+                              'pass the soft line limit'))
+        parser.config_options.append('permissive-bulkiness-percentage')
 
     @classmethod
     def parse_options(cls, options):
+        # We implement our own line-length checker because it's not possible to
+        # customize how another checker does its checking.
+        options.ignore += 'E501',
+        cls.options = options
+
+        # This vastly speeds up the test suite, since parse_options is called
+        # on every test now, and venusian does a lot of work.
+        if cls.collected_checkers is not None:
+            return
+
         collected_checkers = []
 
         def register_checker(pattern, checker, extra):
@@ -145,17 +211,21 @@ class EbbLint(object):
         cls.collected_checkers = collected_checkers
 
     @property
+    def source(self):
+        if self._source is None:
+            self._source = read_file_using_source_encoding(self.filename)
+        return self._source
+
+    @property
     def lines(self):
         if self._lines is None:
-            with open(self.filename) as infile:
-                self._lines = Lines(infile)
+            self._lines = Lines(self.source.splitlines(True))
         return self._lines
 
     def _message_for_node(self, node, error, **kw):
         line_offset = kw.pop('line_offset', None)
         if line_offset is None:
-            byte, _ = self.lines[node.lineno]
-            byte += node.column + kw.pop('offset', 0)
+            byte = self.lines.byte_of_node(node) + kw.pop('offset', 0)
             lineno, column = self.lines.position_of_byte(byte)
         else:
             lineno = node.lineno + line_offset
@@ -171,19 +241,75 @@ class EbbLint(object):
     def run(self):
         d = driver.Driver(
             grammar_for_filename(self.filename), convert=pytree.convert)
-        tree, trailing_newline = parse_file(d, self.filename)
+        tree, trailing_newline = parse_source(d, self.source)
         if not trailing_newline:
             yield self._message_for_pos(
                 self.lines.last_pos, Errors.no_trailing_newline)
+
+        for error in self._check_tree(tree):
+            yield error
+
+        for error in self._check_line_lengths():
+            yield error
+
+    def _check_tree(self, tree):
         for node in tree.pre_order():
+            self._scan_node_for_ranges(node)
             for pattern, checker, extra in self.collected_checkers:
                 results = {}
                 if not pattern.match(node, results):
                     continue
                 for k in extra.get('comments_for', ()):
-                    comments = list(find_comments(node.prefix))
-                    results[k + '_comments'] = comments
+                    results[k + '_comments'] = [
+                        c for c, _ in find_comments(node.prefix)]
                 if extra.get('pass_filename', False):
                     results['filename'] = self.filename
                 for error_node, error, kw in checker(**results):
                     yield self._message_for_node(error_node, error, **kw)
+
+    def _scan_node_for_ranges(self, node):
+        if node.children or (node.type != token.STRING and not node.prefix):
+            return
+
+        byte = self.lines.byte_of_node(node)
+
+        if node.type == token.STRING:
+            self._intervals['string literals'].add(Interval(
+                byte, byte + len(node.value)))
+
+        comments = list(
+            find_comments(node.prefix, byte - len(node.prefix)))
+        for c, i in comments:
+            self._intervals['comments'].add(i)
+
+    def _check_line_lengths(self):
+        soft_limit = self.options.max_line_length
+        hard_limit = self.options.hard_max_line_length
+        permitted_percentage = self.options.permissive_bulkiness_percentage
+        for lineno, line_start, line in self.lines:
+            line = line.rstrip('\r\n')
+            if len(line) <= soft_limit:
+                continue
+            if len(line) > hard_limit:
+                yield self._message_for_pos(
+                    (lineno, hard_limit), Errors.line_too_long,
+                    length=len(line), which_limit='hard', limit=hard_limit,
+                    extra='')
+                continue
+
+            percentages = {}
+            for name, i in self._intervals.items():
+                intersection = i.search(line_start, line_start + len(line))
+                n_bytes = byte_cardinality(intersection)
+                percentages[name] = n_bytes * 100 // len(line)
+
+            if any(p >= permitted_percentage for p in percentages.values()):
+                continue
+
+            extra = ' since the line has ' + '; '.join(
+                '{p}% {name}'.format(p=p, name=name)
+                for name, p in percentages.items())
+            yield self._message_for_pos(
+                (lineno, soft_limit), Errors.line_too_long,
+                length=len(line), which_limit='soft', limit=soft_limit,
+                extra=extra)

--- a/ebb_lint/test/test_flake8.py
+++ b/ebb_lint/test/test_flake8.py
@@ -491,6 +491,53 @@ A = 'bcdeAbcd'  # eA
 ])
 
 
+hard_limit_only_test_mark = pytest.mark.flake8_args(
+    '--max-line-length', '15', '--hard-max-line-length', '15')
+all_sources.extend(hard_limit_only_test_mark(s) for s in [
+    '''
+
+AbcdeAbcdeAbcde
+
+    ''',
+
+    '''
+
+AbcdeAbcdeAbcde$L302$f
+
+    ''',
+
+    '''
+
+AbcdeAbcdeAbcd $L302$= 'e'
+
+    ''',
+
+    '''
+
+A = 'bcdeAbcdeA$L302$bcde'
+
+    ''',
+
+    '''
+
+A = 'bcdeAbcd' $L302$ # eA
+
+    ''',
+
+    '''
+
+AbcdeAbcdeAbcde$L302$AbcdeAbcdef
+
+    ''',
+
+    '''
+
+AbcdeAbcdeAbcde$L302$AbcdeAbcdefghijklmnopqrstuvwxyz
+
+    ''',
+])
+
+
 contexts = [
     ('# I sincerely swear that this is one-off code.', ''),
 

--- a/ebb_lint/test/test_flake8.py
+++ b/ebb_lint/test/test_flake8.py
@@ -1,11 +1,13 @@
 from __future__ import unicode_literals
 
 import ast
+import functools
 import re
 import sys
 
 import pytest
 import six
+from flake8.engine import get_parser
 
 from ebb_lint.flake8 import EbbLint, Lines
 
@@ -37,10 +39,17 @@ def find_error_locations(source):
         lines.position_of_byte(b) + (code,) for b, code, _ in error_locations]
 
 
-@pytest.fixture(autouse=True, scope='session')
-def scan_for_checkers():
-    EbbLint.add_options(None)
-    EbbLint.parse_options(None)
+@pytest.fixture(autouse=True)
+def scan_for_checkers(request):
+    parser, options_hooks = get_parser()
+    args_marker = request.node.get_marker('flake8_args')
+    if args_marker is None:
+        args = []
+    else:
+        args = list(args_marker.args)
+    opts, args = parser.parse_args(args)
+    opts.ignore = tuple(opts.ignore)
+    EbbLint.parse_options(opts)
 
 
 all_sources = [
@@ -373,6 +382,113 @@ class C(object):
 
     ''',
 ]
+
+
+line_length_test_mark_generator = functools.partial(
+    pytest.mark.flake8_args,
+    '--max-line-length', '15', '--hard-max-line-length', '25')
+
+
+line_length_test_mark = line_length_test_mark_generator()
+all_sources.extend(line_length_test_mark(s) for s in [
+    '''
+
+AbcdeAbcdeAbcde
+
+    ''',
+
+    '''
+
+AbcdeAbcdeAbcde$L302$f
+
+    ''',
+
+    '''
+
+AbcdeAbcdeAbcd $L302$= 'e'
+
+    ''',
+
+    '''
+
+A = 'bcdeAbcdeAbcde'
+
+    ''',
+
+    '''
+
+A = 'bcdeAbcd' $L302$ # eA
+
+    ''',
+
+    '''
+
+AbcdeAbcdeAbcdeAbcdeAbcde$L302$f
+
+    ''',
+
+    '''
+
+AbcdeAbcdeAbcdeAbcdeAbcde$L302$fghijklmnopqrstuvwxyz
+
+    ''',
+])
+
+
+def permissive_percentage_test_mark(p, s):
+    return line_length_test_mark_generator(
+        '--permissive-bulkiness-percentage', str(p))(s)
+
+
+all_sources.extend(permissive_percentage_test_mark(p, s) for p, s in [
+    (100, '''
+
+"AbcdeAbcdeAbcdeAbc"
+
+    '''),
+
+    (100, '''
+
+# AbcdeAbcdeAbcdeAbc
+
+    '''),
+
+    (100, '''
+
+a = "AbcdeAbcde$L302$Abcde"
+
+    '''),
+
+    (100, '''
+
+a # AbcdeAbcdeA$L302$bcdeA
+
+    '''),
+
+    (50, '''
+
+A = 'bcdeAbcd'  # eA
+
+    '''),
+
+    (50, '''
+
+A = 'bcde'  # A$L302$bcdeA
+
+    '''),
+
+    (20, '''
+
+A = 'bcdeAbcd'  # eA
+
+    '''),
+
+    (0, '''
+
+A = 'bcdeAbcd'  # eA
+
+    '''),
+])
 
 
 contexts = [

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ extras_require['all'] = list({
 
 install_requires = [
     'flake8',
+    'intervaltree',
     'six',
     'venusian',
 ]


### PR DESCRIPTION
> After running into issues with 79 columns being good for some
> situations, but less good for others, I finally decided to just write my
> own long line lint thing. It's maybe a bit too heuristic, but we'll see
> how well it works out in practice.

> Basically, it allows lines to be 79 < length <= 119, but only if
> two-thirds of the line are comments or string literals by character
> count.
