### PR TITLE
Fix packaging for across python <3.4 and >=3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
 
 
 install:
+  - "pip install -U pip setuptools"
   - "pip install tox codecov"
 script:
   - "tox -- -rs"


### PR DESCRIPTION
Conditionally changing `install_requires` in `setup.py` directly causes wheels to break across versions. So, fix that.